### PR TITLE
BroadCastReceiver on date_changed started

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,11 @@
         <activity
             android:name=".ChallengeActivity">
         </activity>
+        <receiver android:name=".closing.DeadLineFuckUpReciever">
+            <intent-filter>
+                <action android:name="android.intent.action.DATE_CHANGED"/>
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/v/challengeyourself/Challenge.java
+++ b/app/src/main/java/v/challengeyourself/Challenge.java
@@ -14,15 +14,15 @@ public class Challenge {
     public String challenge;
     public String details;
     public long deadLine;
-    public int done;
+    public int closed;
 
-    public Challenge (String start, String deadDate, String deadTime, String chall, String details, long deadLine, int done) {
+    public Challenge (String start, String deadDate, String deadTime, String chall, String details, long deadLine, int closed) {
         this.start = start;
         this.deadDate = deadDate;
         this.deadTime = deadTime;
         this.challenge = chall;
         this.details = details;
         this.deadLine = deadLine;
-        this.done = done;
+        this.closed = closed;
     }
 }

--- a/app/src/main/java/v/challengeyourself/EditorActivity.java
+++ b/app/src/main/java/v/challengeyourself/EditorActivity.java
@@ -117,7 +117,7 @@ public class EditorActivity extends AppCompatActivity {
                 + ", challenge = " + newch.challenge
                 + ", details = " + newch.details
                 + ", deadLine(time in millis) " + newch.deadLine
-                + ", done? " + newch.done);
+                + ", closed? " + newch.closed);
         storage.put(newch);
         //storage.showStorage();
         storage.sortByDeadLines();

--- a/app/src/main/java/v/challengeyourself/HomeActivity.java
+++ b/app/src/main/java/v/challengeyourself/HomeActivity.java
@@ -1,15 +1,31 @@
 package v.challengeyourself;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.support.v4.content.Loader;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 
+import java.util.Date;
+
+import v.challengeyourself.closing.DeadLineFuckUpReciever;
 import v.challengeyourself.storage.ChallengeStorage;
 import v.challengeyourself.storage.DBHelper;
 
+import static v.challengeyourself.storage.DBContract.Columns.TABLE_NAME;
+import static v.challengeyourself.storage.DBContract.TableColumns.DEADDATE;
+import static v.challengeyourself.storage.DBContract.TableColumns.DEADLINE;
+
 public class HomeActivity extends AppCompatActivity {
+
+    private BroadcastReceiver dateChanged;
 
     void save() {}
 
@@ -56,5 +72,9 @@ public class HomeActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
+
+        dateChanged = new DeadLineFuckUpReciever();
+        //TODO СОБЫТИЕ ДЛЯ РЕСИВЕРА ПОКА ТАКОЕ, НАДО ПОМЕНЯТЬ НА ON_DATA_CHANGED, НО ОНА РАБОТАЕТ ЧЕРЕЗ РАЗ И ТЕСТИТЬ НЕУДОБНО
+        registerReceiver(dateChanged, new IntentFilter(Intent.ACTION_SCREEN_OFF));
     }
 }

--- a/app/src/main/java/v/challengeyourself/closing/DeadLineFuckUpReciever.java
+++ b/app/src/main/java/v/challengeyourself/closing/DeadLineFuckUpReciever.java
@@ -1,0 +1,61 @@
+package v.challengeyourself.closing;
+
+import android.content.BroadcastReceiver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
+import android.widget.Toast;
+
+import java.util.Calendar;
+
+import v.challengeyourself.HomeActivity;
+import v.challengeyourself.storage.ChallengeStorage;
+import v.challengeyourself.storage.DBHelper;
+
+import static v.challengeyourself.storage.DBContract.Columns.TABLE_NAME;
+import static v.challengeyourself.storage.DBContract.TableColumns.DEADLINE;
+
+/**
+ * Created by maria on 18.12.16.
+ */
+public class DeadLineFuckUpReciever extends BroadcastReceiver {
+    public ChallengeStorage storage;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        long currentTime = System.currentTimeMillis();
+        storage = new ChallengeStorage(context);
+        Cursor c = storage.getCursorToSortedTable();
+        long nearest = 0L;
+        if (c.moveToFirst()) {
+            do {
+                nearest = c.getLong(c.getColumnIndex(DEADLINE));
+                if (timeCame(currentTime, nearest)) {
+                    //TODO ЗДЕСЬ ИМЕЕМ ДОСТУП КО ВСЕМ ЧЕЛЕНДЖАМ, КОТОРЫЕ СГОРЯТ СЕГОДНЯ, ПОКА ВЫВОДИТСЯ В ЛОГ, ПОДУМАТЬ ГДЕ ХОТИМ ИХ ВИДЕТЬ
+                    Log.d("TIME CAME ", "current time= " + currentTime + " deadline time " + nearest);
+                }
+            } while (c.moveToNext());
+        }
+        c.close();
+    }
+
+    private Calendar getCalendarFromMillis (long millis) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(millis);
+        return calendar;
+    }
+
+    private boolean timeCame(long system, long deadline) {
+        Calendar s = getCalendarFromMillis(system);
+        Calendar d = getCalendarFromMillis(deadline);
+        if (s.get(Calendar.YEAR) == d.get(Calendar.YEAR)
+                && s.get(Calendar.MONTH) == d.get(Calendar.MONTH)
+                && s.get(Calendar.DAY_OF_MONTH) == d.get(Calendar.DAY_OF_MONTH)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/v/challengeyourself/storage/ChallengeStorage.java
+++ b/app/src/main/java/v/challengeyourself/storage/ChallengeStorage.java
@@ -21,11 +21,11 @@ public class ChallengeStorage {
 
     public ChallengeStorage(Context context) {
         this.context = context;
+        dbHelper = DBHelper.getInstance(context);
+        db = dbHelper.getWritableDatabase();
     }
 
     public void put(Challenge newch) {
-        dbHelper = DBHelper.getInstance(context);
-        db = dbHelper.getWritableDatabase();
         db.beginTransaction();
         Log.d(TAG, "Transaction started");
         SQLiteStatement insert = null;
@@ -37,7 +37,7 @@ public class ChallengeStorage {
                     + CHALLENGE + ", "
                     + DETAILS + ", "
                     + DEADLINE + ", "
-                    + DONE;
+                    + CLOSED;
             String request = ") VALUES (?, ?, ?, ?, ?, ?, ?)";
             insert = db.compileStatement(statement + request);
             int pos = 0;
@@ -47,7 +47,7 @@ public class ChallengeStorage {
             insert.bindString(++pos, newch.challenge);
             insert.bindString(++pos, newch.details);
             insert.bindLong(++pos, newch.deadLine);
-            insert.bindLong(++pos, newch.done);
+            insert.bindLong(++pos, newch.closed);
 
             insert.executeInsert();
             db.setTransactionSuccessful();
@@ -62,8 +62,13 @@ public class ChallengeStorage {
         watchTableByCursor(c);
     }
 
-    public void sortByDeadLines() {
+    public Cursor getCursorToSortedTable() {
         Cursor c = db.rawQuery("SELECT * FROM " + TABLE_NAME + " ORDER BY " + DEADLINE + " ASC", null);
+        return c;
+    }
+
+    public void sortByDeadLines() {
+        Cursor c = getCursorToSortedTable();
         watchTableByCursor(c);
     }
 
@@ -77,7 +82,7 @@ public class ChallengeStorage {
             int ci = c.getColumnIndex(CHALLENGE);
             int di = c.getColumnIndex(DETAILS);
             int timei = c.getColumnIndex(DEADLINE);
-            int donei = c.getColumnIndex(DONE);
+            int closei = c.getColumnIndex(CLOSED);
 
             do {
                 Log.d(TAG, "id = " + c.getInt(idi) + "start = " + c.getString(si)
@@ -86,12 +91,11 @@ public class ChallengeStorage {
                         + ", challenge=" + c.getString(ci)
                         + ", details=" + c.getString(di)
                         + ", deadline=" + c.getLong(timei)
-                        + ", done=" + c.getLong(donei));
+                        + ", closed=" + c.getLong(closei));
             } while (c.moveToNext());
         } else {
             Log.d(TAG, "0 rows");
         }
         c.close();
     }
-
 }

--- a/app/src/main/java/v/challengeyourself/storage/DBContract.java
+++ b/app/src/main/java/v/challengeyourself/storage/DBContract.java
@@ -14,7 +14,7 @@ public class DBContract {
         String CHALLENGE = "challenge";
         String DETAILS = "details";
         String DEADLINE = "deadline";
-        String DONE = "done";
+        String CLOSED = "closed";
     }
 
     public static final class Columns implements TableColumns {
@@ -29,7 +29,7 @@ public class DBContract {
                 + CHALLENGE + " TEXT, "
                 + DETAILS  + " TEXT, "
                 + DEADLINE + " INTEGER, "
-                + DONE + " INTEGER"
+                + CLOSED + " INTEGER"
                 + ")";
     }
 


### PR DESCRIPTION
К HomeActivity прикреплен BroadCastReciever
событие (on screen off) временное, но пока оставлено, как адекватно срабатывающее
в Ресивере DeadLineFuckUpReciever можно обратиться к событиям, сгорающим сегодня, пока они выводятся только в лог